### PR TITLE
fix: update Web Player URL references in embed messages

### DIFF
--- a/src/api/controllers/guild/home.controller.ts
+++ b/src/api/controllers/guild/home.controller.ts
@@ -79,7 +79,7 @@ class HomeController {
 			});
 			const message = new EmbedBuilder()
 				.setColor(this.client.config.color.main)
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild?.id}/room)]`} ${authMode ? 'Enabled' : 'Disabled'} authentication mode`);
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild?.id}/room)]`} ${authMode ? 'Enabled' : 'Disabled'} authentication mode`);
 			await channel?.send({ embeds: [message] });
 
 			response.success(res, {
@@ -115,7 +115,7 @@ class HomeController {
 
 			const message = new EmbedBuilder()
 				.setColor(this.client.config.color.main)
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild?.id}/room)]`} ${silentMode ? 'Enabled' : 'Disabled'} silent mode`);
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild?.id}/room)]`} ${silentMode ? 'Enabled' : 'Disabled'} silent mode`);
 			await channel?.send({ embeds: [message] });
 
 			response.success(res, {

--- a/src/api/controllers/guild/music.controller.ts
+++ b/src/api/controllers/guild/music.controller.ts
@@ -104,6 +104,12 @@ class MusicController {
 				}
 
 				customNode = result.node;
+				if (customNode) {
+					const message = new EmbedBuilder()
+						.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Using lavalink server: ${lavalink.NodeName}`)
+						.setColor(this.client.color.main);
+					await textChannelObj.send({ embeds: [message] });
+				}
 			}
 
 			const newPlayer = this.client.manager.createPlayer({
@@ -130,7 +136,7 @@ class MusicController {
 			}
 
 			const message = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Joined <#${voiceChannel}> and bound to <#${textChannel}>`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Joined <#${voiceChannel}> and bound to <#${textChannel}>`)
 				.setColor(this.client.color.main);
 			await textChannelObj.send({ embeds: [message] });
 
@@ -153,7 +159,7 @@ class MusicController {
 			await player!.destroy();
 
 			const message = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Disconnected`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Disconnected`)
 				.setColor(this.client.color.main);
 			await channel!.send({ embeds: [message] });
 
@@ -172,7 +178,7 @@ class MusicController {
 			await player!.connect();
 
 			const message = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Reconnected`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Reconnected`)
 				.setColor(this.client.color.main);
 			await channel!.send({ embeds: [message] });
 
@@ -222,7 +228,7 @@ class MusicController {
 			});
 
 			const message = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Added [${track.info.title}](${track.info.uri})`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Added [${track.info.title}](${track.info.uri})`)
 				.setColor(this.client.color.main);
 
 			if (!player!.get('silentMode')) {
@@ -264,7 +270,7 @@ class MusicController {
 			});
 
 			const message = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Removed [${track.info.title}](${track.info.uri})`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Removed [${track.info.title}](${track.info.uri})`)
 				.setColor(this.client.color.main);
 
 			if (!player!.get('silentMode')) {
@@ -337,7 +343,7 @@ class MusicController {
 			});
 
 			const message = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Seeked to ${this.client.utils.formatTime(position)}`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Seeked to ${this.client.utils.formatTime(position)}`)
 				.setColor(this.client.color.main);
 
 			if (!player!.get('silentMode')) {
@@ -379,7 +385,7 @@ class MusicController {
 			});
 
 			const message = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Paused the player`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Paused the player`)
 				.setColor(this.client.color.main);
 
 			if (!player!.get('silentMode')) {
@@ -417,7 +423,7 @@ class MusicController {
 			});
 
 			const message = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Resumed the player`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Resumed the player`)
 				.setColor(this.client.color.main);
 
 			if (!player!.get('silentMode')) {
@@ -458,7 +464,7 @@ class MusicController {
 			});
 
 			const message = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Skipped to next track`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Skipped to next track`)
 				.setColor(this.client.color.main);
 
 			if (!player!.get('silentMode')) {
@@ -492,7 +498,7 @@ class MusicController {
 			});
 
 			const message = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Rewound the track`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Rewound the track`)
 				.setColor(this.client.color.main);
 
 			if (!player!.get('silentMode')) {
@@ -530,7 +536,7 @@ class MusicController {
 			});
 
 			const message = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Enabled track loop`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Enabled track loop`)
 				.setColor(this.client.color.main);
 
 			if (!player!.get('silentMode')) {
@@ -568,7 +574,7 @@ class MusicController {
 			});
 
 			const message = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Disabled track loop`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Disabled track loop`)
 				.setColor(this.client.color.main);
 
 			if (!player!.get('silentMode')) {
@@ -604,7 +610,7 @@ class MusicController {
 			});
 
 			const message = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Shuffled the queue`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Shuffled the queue`)
 				.setColor(this.client.color.main);
 
 			if (!player!.get('silentMode')) {

--- a/src/api/controllers/guild/playlist.controller.ts
+++ b/src/api/controllers/guild/playlist.controller.ts
@@ -164,7 +164,7 @@ class PlaylistController {
 			}
 
 			const loadMessage = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Adding playlist ${playlist.PlaylistName} to queue...`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Adding playlist ${playlist.PlaylistName} to queue...`)
 				.setColor(this.client.color.main);
 
 			const messageSend = await channel!.send({ embeds: [loadMessage] });
@@ -185,7 +185,7 @@ class PlaylistController {
 			});
 
 			const message = new EmbedBuilder()
-				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${process.env.APP_CLIENT_URL}/guild/${guild!.id}/room)]`} Loaded playlist ${playlist.PlaylistName}`)
+				.setDescription(`${user?.username ? `[${user.username}]` : `[[Web Player](${this.client.env.WEB_PLAYER_URL}/guild/${guild!.id}/room)]`} Loaded playlist ${playlist.PlaylistName}`)
 				.setColor(this.client.color.main);
 
 			await messageSend.edit({ embeds: [message] });

--- a/src/events/client/MessageCreate.ts
+++ b/src/events/client/MessageCreate.ts
@@ -60,7 +60,7 @@ export default class MessageCreate extends Event {
 		if (!cmd) return;
 		const command = this.client.commands.get(cmd) || this.client.commands.get(this.client.aliases.get(cmd) as string);
 		if (!command) return;
-		const allowedCommands = ['play', 'join', 'ping', 'help', 'webplayer', 'leave'];
+		const allowedCommands = ['play', 'join', 'ping', 'help', 'webplayer'];
 		if (!(allowedCommands.includes(cmd) || command.permissions?.dev)) return;
 
 		const ctx = new Context(message, args);

--- a/src/structures/Lavamusic.ts
+++ b/src/structures/Lavamusic.ts
@@ -183,7 +183,7 @@ export default class Lavamusic extends Client {
 
 		try {
 			const rest = new REST({ version: '10' }).setToken(env.TOKEN ?? '');
-			const allowedCommands = ['play', 'join', 'ping', 'help', 'webplayer', 'leave'];
+			const allowedCommands = ['play', 'join', 'ping', 'help', 'webplayer'];
 			const filteredBody = this.body.filter(data => allowedCommands.includes(data.name));
 			await rest.put(route, { body: filteredBody });
 			this.logger.info('Successfully deployed slash commands!');


### PR DESCRIPTION
- Replaced instances of `process.env.APP_CLIENT_URL` with `this.client.env.WEB_PLAYER_URL` in embed message descriptions across HomeController, MusicController, and PlaylistController to ensure consistent URL usage.
- Improved embed messages in MusicController to include additional context when using custom Lavalink nodes.
- Cleaned up allowed commands in MessageCreate and Lavamusic classes by removing the 'leave' command, streamlining command handling.