### PR TITLE
feat: add volume control and update allowed commands

### DIFF
--- a/src/api/controllers/guild/music.controller.ts
+++ b/src/api/controllers/guild/music.controller.ts
@@ -119,6 +119,7 @@ class MusicController {
 				selfMute: false,
 				selfDeaf: true,
 				vcRegion: voiceChannelObj.rtcRegion!,
+				volume: 70,
 				node: customNode
 			});
 

--- a/src/commands/music/Join.ts
+++ b/src/commands/music/Join.ts
@@ -63,6 +63,7 @@ export default class Join extends Command {
 			selfMute: false,
 			selfDeaf: true,
 			vcRegion: memberVoiceChannel.rtcRegion!,
+			volume: 70,
 		});
 		if (!player.connected) await player.connect();
 		return await ctx.sendMessage({

--- a/src/events/client/MessageCreate.ts
+++ b/src/events/client/MessageCreate.ts
@@ -60,7 +60,7 @@ export default class MessageCreate extends Event {
 		if (!cmd) return;
 		const command = this.client.commands.get(cmd) || this.client.commands.get(this.client.aliases.get(cmd) as string);
 		if (!command) return;
-		const allowedCommands = ['play', 'join', 'ping', 'help', 'webplayer'];
+		const allowedCommands = ['play', 'join', 'leave', 'ping', 'help', 'webplayer'];
 		if (!(allowedCommands.includes(cmd) || command.permissions?.dev)) return;
 
 		const ctx = new Context(message, args);

--- a/src/structures/Lavamusic.ts
+++ b/src/structures/Lavamusic.ts
@@ -183,7 +183,7 @@ export default class Lavamusic extends Client {
 
 		try {
 			const rest = new REST({ version: '10' }).setToken(env.TOKEN ?? '');
-			const allowedCommands = ['play', 'join', 'ping', 'help', 'webplayer'];
+			const allowedCommands = ['play', 'join', 'leave', 'ping', 'help', 'webplayer'];
 			const filteredBody = this.body.filter(data => allowedCommands.includes(data.name));
 			await rest.put(route, { body: filteredBody });
 			this.logger.info('Successfully deployed slash commands!');


### PR DESCRIPTION
- Introduced a default volume setting of 70 in the MusicController and Join command to enhance user experience.
- Updated the allowed commands list in MessageCreate and Lavamusic classes to include 'leave', improving command handling consistency.